### PR TITLE
Modify RGB

### DIFF
--- a/components/ColourBox.js
+++ b/components/ColourBox.js
@@ -5,7 +5,7 @@ import decideColour from "../lib/decideColour";
 export default function ColourBox(props) {
   const [copied, setCopied] = useState(false);
 
-  const colourValue = decideColour(props.hex);
+  const colourValue = decideColour(props.rgb);
 
   const boxStyle = {
     backgroundColor: "#" + props.hex,

--- a/components/PaletteBox.js
+++ b/components/PaletteBox.js
@@ -13,7 +13,7 @@ export default function PaletteBox(props) {
       }
     >
       {props.coloursList.map((colour, index) => {
-        return <ColourBox key={index} hex={colour} />;
+        return <ColourBox key={index} hex={colour.hex} rgb = {colour.rgb} />;
       })}
     </div>
   );

--- a/lib/colours.js
+++ b/lib/colours.js
@@ -4,7 +4,7 @@ function generatePalette(colour) {
   return new Values(colour)
     .all(25)
     .slice(2, 7)
-    .map((obj) => obj.hex);
+    .map((obj) => ({ hex: obj.hex, rgb: obj.rgb }));
 }
 
 export default generatePalette;

--- a/lib/decideColour.js
+++ b/lib/decideColour.js
@@ -1,8 +1,5 @@
-export default function decideColour(bgColour) {
-  const hexValue = bgColour.split("");
-  const rgb = [];
-  while (hexValue.length) rgb.push(hexValue.splice(0, 2).join(""));
-  const [red, green, blue] = rgb.map((hexStr) => parseInt(hexStr, 16));
+export default function decideColour(rgb) {
+  const [red, green, blue] = [...rgb];
 
   return red * 0.299 + green * 0.587 + blue * 0.114 > 150
     ? "#212427"


### PR DESCRIPTION
To determine the font colour of the text of each **Colour Box**, the app previously obtained the required RGB values for each colour from the HEX value it received. This was unnecessary because the object that Values.js returned for each colour contained the RGB values as well. 
The app has now been modified to use the RGB values that Values.js provides.